### PR TITLE
New service provider deepinfra

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,41 +1,41 @@
 import { options } from './constant';
-import azure from './proxy/azure';
 import groq from './proxy/groq';
-import openAi from './proxy/openai';
-import globalGPT from './proxy/glbgpt';
 import coze from './proxy/coze';
+import azure from './proxy/azure';
+import openai from './proxy/openai';
+import glbgpt from './proxy/glbgpt';
+import deepinfra from './proxy/deepinfra';
 import { JSONParse } from './utils';
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    const TOKEN_MAPPER = {
-      [env.GROQ_CLOUD_TOKEN]: groq,
-      [env.AZURE_OPENAI_CUSTOM_KEY]: azure,
-      [env.OPENAI_API_KEY]: openAi,
-      [env.GLOBALGPT_API_KEY]: globalGPT,
-      [env.COZE_API_KEY]: coze,
-    };
+    const services: { [key: string]: IProxy } = { groq, azure, openai, glbgpt, coze, deepinfra };
     const url = new URL(request.url);
     if (request.method === 'OPTIONS') return options;
 
     const authKey = request.headers.get('Authorization')?.replace('Bearer', '')?.trim();
-    if (!authKey || !Object.keys(TOKEN_MAPPER).includes(authKey)) return new Response('Not allowed', { status: 403 });
+    if (!authKey) return new Response('Not allowed', { status: 403 });
+
+    const [token, serviceName] = authKey.split('##');
+    if (!token || !serviceName || env.CUSTOM_KEY !== token || !services[serviceName]) return new Response('Not allowed', { status: 403 });
 
     const body = request.method === 'POST' ? await request.json() : null;
 
-    const objValue: (keyof Env)[] = ['AZURE_DEPLOY_NAME', 'AZURE_API_KEYS'];
-    objValue.forEach((key) => {
-      if (!env[key]) return;
-      try {
-        if (typeof env[key] === 'string') env[key] = JSON.parse(env[key] as string);
-      } catch (error) {
-        delete env[key];
-        console.error(error);
-      }
-    });
-    if (env.AZURE_DEPLOY_NAME && typeof env.AZURE_DEPLOY_NAME === 'string') env.AZURE_DEPLOY_NAME = JSONParse(env.AZURE_DEPLOY_NAME);
-    if (env.AZURE_API_KEYS && typeof env.AZURE_API_KEYS === 'string') env.AZURE_API_KEYS = JSONParse(env.AZURE_API_KEYS);
+    if (serviceName === 'azure') {
+      const objValue: (keyof Env)[] = ['AZURE_DEPLOY_NAME', 'AZURE_API_KEYS'];
+      objValue.forEach((key) => {
+        if (!env[key]) return;
+        try {
+          if (typeof env[key] === 'string') env[key] = JSON.parse(env[key] as string);
+        } catch (error) {
+          delete env[key];
+          console.error(error);
+        }
+      });
+      if (env.AZURE_DEPLOY_NAME && typeof env.AZURE_DEPLOY_NAME === 'string') env.AZURE_DEPLOY_NAME = JSONParse(env.AZURE_DEPLOY_NAME);
+      if (env.AZURE_API_KEYS && typeof env.AZURE_API_KEYS === 'string') env.AZURE_API_KEYS = JSONParse(env.AZURE_API_KEYS);
+    }
 
-    return TOKEN_MAPPER[authKey](request, authKey, body, url, env);
+    return services[serviceName](request, body, url, env);
   },
 };

--- a/src/proxy/azure.ts
+++ b/src/proxy/azure.ts
@@ -57,7 +57,7 @@ const getResourceNameAndToken = (model: string, env: Env) => {
   return resourceInfo;
 };
 
-const proxy: IProxy = async (request: Request, _: string, body: any, url: URL, env: Env) => {
+const proxy: IProxy = async (request: Request, body: any, url: URL, env: Env) => {
   // Remove the leading /v1/ from url.pathname
   const action = url.pathname.replace(/^\/+v1\/+/, '');
 

--- a/src/proxy/coze.ts
+++ b/src/proxy/coze.ts
@@ -115,7 +115,7 @@ const convertToOpenAIFormat = async (params: IConvertToOpenAIFormatParams) => {
   writer.close();
 };
 
-const proxy: IProxy = async (request: Request, token: string, body: any, url: URL, env: Env) => {
+const proxy: IProxy = async (request: Request, body: any, url: URL, env: Env) => {
   // Remove the leading /v1/ from url.pathname
   const action = url.pathname.replace(/^\/+v1\/+/, '');
 
@@ -168,7 +168,7 @@ const proxy: IProxy = async (request: Request, token: string, body: any, url: UR
       Accept: '*/*',
       Host: 'api.coze.com',
       Connection: 'keep-alive',
-      Authorization: `Bearer ${token}`,
+      Authorization: `Bearer ${env.COZE_API_KEY}`,
     },
     body: JSON.stringify({ bot_id, conversation_id: '', user: 'User', query, chat_history, stream, custom_variables }),
   };

--- a/src/proxy/deepinfra.ts
+++ b/src/proxy/deepinfra.ts
@@ -1,0 +1,44 @@
+import { models, generativeModelMappings, JSONParse, isNotEmpty, listLen } from '../utils';
+
+const proxy: IProxy = async (request: Request, body: any, url: URL, env: Env) => {
+  const action = url.pathname.replace(/^\/+v1\/+/, '');
+
+  if (env.DEEPINFRA_DEPLOY_NAME && typeof env.DEEPINFRA_DEPLOY_NAME === 'string') env.DEEPINFRA_DEPLOY_NAME = JSONParse(env.DEEPINFRA_DEPLOY_NAME);
+  if (!isNotEmpty(env.DEEPINFRA_DEPLOY_NAME)) {
+    return new Response('404 Not Found', { status: 404 });
+  }
+
+  let [gpt35, gpt4] = Array(2).fill(env.DEEPINFRA_DEPLOY_NAME[0].modelName);
+  const otherMapping: { [key: string]: string } = Object.create(null);
+
+  if (listLen(env.DEEPINFRA_DEPLOY_NAME) > 1) {
+    env.DEEPINFRA_DEPLOY_NAME.forEach((item) => {
+      if (item.alias) otherMapping[item.alias] = item.modelName;
+      if (item.modelName) otherMapping[item.modelName] = item.modelName;
+      if (item.gpt35Default || item.gpt4Default) {
+        if (item.gpt35Default) gpt35 = item.modelName;
+        if (item.gpt4Default) gpt4 = item.modelName;
+      }
+    });
+  }
+
+  const MODELS_MAPPING = generativeModelMappings(gpt35, gpt4, otherMapping);
+
+  if (action === 'models') return models(MODELS_MAPPING);
+
+  const payload = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${env.DEEPINFRA_API_KEY}`,
+    },
+    body: '{}',
+  };
+  if (body) {
+    body.model = MODELS_MAPPING[body?.model as OPEN_AI_MODELS] ?? gpt35;
+    payload.body = JSON.stringify(body);
+  }
+  return fetch(`https://api.deepinfra.com/v1/openai/${action}`, payload);
+};
+
+export default proxy;

--- a/src/proxy/glbgpt.ts
+++ b/src/proxy/glbgpt.ts
@@ -122,7 +122,7 @@ const createNewChatAndReplyMessage = async ({
   return new Response(readable);
 };
 
-const proxy: IProxy = async (request: Request, token: string, body: any, url: URL, env: Env) => {
+const proxy: IProxy = async (request: Request, body: any, url: URL, env: Env) => {
   // Remove the leading /v1/ from url.pathname
   const action = url.pathname.replace(/^\/+v1\/+/, '');
 
@@ -151,7 +151,7 @@ const proxy: IProxy = async (request: Request, token: string, body: any, url: UR
     headers: {
       'Content-Type': 'application/json',
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36 Edg/123.0.0.0',
-      Token: token,
+      Token: env.GLOBALGPT_API_KEY,
     },
     body: '{}',
   };

--- a/src/proxy/groq.ts
+++ b/src/proxy/groq.ts
@@ -37,9 +37,6 @@ import { models, generativeModelMappings } from '../utils';
 const MODELS = ['llama3-8b-8192', 'llama3-70b-8192', 'llama2-70b-4096', 'mixtral-8x7b-32768', 'gemma-7b-it'];
 const [LLaMA3_8b_8k, LLaMA3_70b_8k, LLaMA2_70b_8k, Mixtral_8x7b_32k, Gemma_7b_8k] = MODELS;
 
-const MODELS_MAP: { [key: string]: string } = Object.create(null);
-MODELS.forEach((model) => (MODELS_MAP[model] = model));
-
 /**
  * LLaMA3_8b_8k => GPT-3.5 Turbo
  * LLaMA3_70b_8k => GPT-4 Turbo
@@ -49,10 +46,10 @@ MODELS.forEach((model) => (MODELS_MAP[model] = model));
 const MODELS_MAPPING = generativeModelMappings(LLaMA3_8b_8k, LLaMA3_70b_8k, {
   'gpt-4-turbo-2024-04-09': Mixtral_8x7b_32k,
   'gpt-3.5-turbo-0125': Gemma_7b_8k,
-  ...MODELS_MAP,
+  ...MODELS.reduce((acc, model) => ({ ...acc, [model]: model }), {}),
 });
 
-const proxy: IProxy = (request: Request, token: string, body: any, url: URL, env: Env) => {
+const proxy: IProxy = (request: Request, body: any, url: URL, env: Env) => {
   const action = url.pathname.replace(/^\/+v1\/+/, '');
 
   if (action === 'models') return models(MODELS_MAPPING);
@@ -61,7 +58,7 @@ const proxy: IProxy = (request: Request, token: string, body: any, url: URL, env
     method: request.method,
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
+      Authorization: `Bearer ${env.GROQ_CLOUD_TOKEN}`,
     },
     body: '{}',
   };

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -11,12 +11,12 @@
  * @param env
  * @returns
  */
-const proxy: IProxy = (request: Request, token: string, body: any, url: URL, env: Env) => {
+const proxy: IProxy = (request: Request, body: any, url: URL, env: Env) => {
   const payload = {
     method: request.method,
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
+      Authorization: `Bearer ${env.OPENAI_API_KEY}`,
     },
     body: body ? JSON.stringify(body) : '{}',
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 type OPEN_AI_MODELS =
+  | 'gpt-4-turbo-2024-04-09'
   | 'gpt-4-0125-preview'
   | 'gpt-4-turbo-preview'
   | 'gpt-4-1106-preview'
@@ -16,7 +17,7 @@ type OPEN_AI_MODELS =
   | 'gpt-3.5-turbo-0613'
   | 'gpt-3.5-turbo-16k-0613';
 
-type IProxy = (request: Request, token: string, body: any, url: URL, env: Env) => Promise<Response>;
+type IProxy = (request: Request, body: any, url: URL, env: Env) => Promise<Response>;
 
 interface AzureKey {
   resourceName: string;
@@ -44,26 +45,60 @@ interface CozeBot {
   gpt4Default?: boolean;
 }
 
+interface DeepinfraModel {
+  modelName: string;
+  alias?: string;
+  gpt35Default?: boolean;
+  gpt4Default?: boolean;
+}
+
 interface Env {
   /**
-   * Azure Open AI Custom Key:
-   * The configuration here is not an actual Azure API Key, but a custom key you define.
-   * When the service receives this key, the program will understand that Azure services need to be used.
-   * Since Azure is region-specific, you may need to configure multiple real keys.
-   * However, the key here is used solely for service routing identification and can also ensure the security of the key.
-   * You can change it at any time as you wish.
+   * The key to be used for the custom key
+   * For example, if the key is `sk-xxxxxx##azure`, the service provider is `azure`, the service will route to the Azure service
    */
-  AZURE_OPENAI_CUSTOM_KEY: string;
-  AZURE_API_KEYS: AzureKey[];
-  AZURE_DEPLOY_NAME: AzureDeployName[];
+  CUSTOM_KEY: string;
+
+  /**
+   * Azure Configuration
+   * @website https://azure.com
+   */
+  AZURE_API_KEYS?: AzureKey[];
+  AZURE_DEPLOY_NAME?: AzureDeployName[];
   AZURE_API_VERSION?: string;
-  GROQ_CLOUD_TOKEN: string;
-  OPENAI_API_KEY: string;
   AZURE_GATEWAY_URL?: string;
+
+  /**
+   * Groq Cloud Configuration
+   * @website https://console.groq.com/docs/quickstart
+   */
+  GROQ_CLOUD_TOKEN: string;
+
+  /**
+   * OpenAI Configuration
+   * @website https://platform.openai.com/docs/api-reference
+   */
+  OPENAI_API_KEY: string;
   OPENAI_GATEWAY_URL?: string;
 
+  /**
+   * GlobalGPT Configuration
+   * @website https://glbgpt.com/chat
+   * @deprecated
+   */
   GLOBALGPT_API_KEY: string;
 
+  /**
+   * Coze Configuration
+   * @website https://www.coze.com/open
+   */
   COZE_API_KEY: string;
   COZE_BOT_IDS: CozeBot[];
+
+  /**
+   * DeepInfra Configuration
+   * @website https://deepinfra.com
+   */
+  DEEPINFRA_API_KEY: string;
+  DEEPINFRA_DEPLOY_NAME: DeepinfraModel[];
 }


### PR DESCRIPTION
Today, I'm thrilled to announce another significant update to the OpenAI Conversion Proxy - the introduction of support for DeepInfra AI services. This new feature seamlessly integrates with the familiar OpenAI-style interface, marking an important step in the diversification of our AI service offerings. It not only delivers swift response times but also supports the latest Meta-Llama3 series models and introduces a variety of model configurations.

🔧 Configuration Update in wrangler.toml:
To welcome this exciting expansion, I've updated the wrangler.toml file as follows:

```toml
name = "openai-conversion-proxy"
main = "src/index.ts"
compatibility_date = "2024-04-24"

[vars]
CUSTOM_KEY = "sk-xxx"
DEEPINFRA_API_KEY = "xxxx"
DEEPINFRA_DEPLOY_NAME = [
	{ "modelName" = "meta-llama/Meta-Llama-3-8B-Instruct", "gpt35Default" = true },
	{ "modelName" = "meta-llama/Meta-Llama-3-70B-Instruct", "gpt4Default" = true },
]
```

Please ensure to replace "sk-xxx" with your custom key used for connecting the client to this proxy service, and "xxxx" with your actual DeepInfra API key.

🚀 Deploying the Update:
Deploying this update is as simple as running:

```shell
npm run deploy
```

🔑 Obtaining the DeepInfra API Key:

The DeepInfra API key can be generated on the DeepInfra Console's API Keys page by clicking the "add new key" button. You can generate it by visiting the [DeepInfra API Keys Page](https://deepinfra.com/dash/api_keys).
This API key is essential for integrating DeepInfra's cutting-edge AI services into your projects.

✨ Value and Advantages:
DeepInfra offers swift response times and supports the latest AI models with a variety of configuration options. For more details on DeepInfra's pricing, please visit the [DeepInfra Pricing Page](https://deepinfra.com/pricing).

For those OpenAI clients that do not support custom model configurations, the model mapping relationship is as follows:

Meta-Llama-3-8B-Instruct => GPT-3.5 Turbo
Meta-Llama-3-70B-Instruct => GPT-4 Turbo
By integrating DeepInfra support into the OpenAI Conversion Proxy, we are expanding the range of AI services and functionalities. This upgrade not only enriches the AI experience but also ensures that a broader spectrum of tools and capabilities is available for various project needs. I look forward to you exploring the new opportunities this update brings to your AI projects.

🌟 Let's embark on this exciting journey together, leveraging the power of AI to unlock new potentials and possibilities!

🔄 Routing Update:
In this update, when routing between different AI service providers, we use a fixed CUSTOM_KEY followed by the service provider's name for switching, such as:

```plaintext
sk-xxxx##deepinfra
sk-xxxx##azure
sk-xxxx##coze
```

This new routing mechanism allows us to flexibly switch between different AI service providers to accommodate varying business and technical requirements.