### PR TITLE
Add support for Groq gateway proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ AZURE_DEPLOY_NAME = [
 - **DeepInfra**: Configured with `DEEPINFRA_API_KEY` and `DEEPINFRA_DEPLOY_NAME`.
 - **GROQ**: Configured with `GROQ_API_KEY`.
 
+## Supplementary Explanation for the Current Revision
+
+With the latest update, Groq now supports the configuration of gateway proxies, enhancing the flexibility and control over request routing. This feature is particularly useful for managing traffic and optimizing performance across different regions or networks. The `wrangler.toml` file has been updated to include a new variable `GROQ_GATEWAY_URL`, allowing users to specify the Groq gateway URL directly. This addition ensures that requests to Groq can be efficiently routed through the specified gateway proxy, providing an additional layer of customization for users leveraging Groq's powerful AI capabilities.
+
 ## Usage Details
 
 ### Token Rules

--- a/src/proxy/groq.ts
+++ b/src/proxy/groq.ts
@@ -26,7 +26,8 @@ const proxy: IProxy = async (action: string, body: any, env: Env, builtIn?: bool
   }
   const payload = openAiPayload({ token: env.GROQ_CLOUD_TOKEN, body });
 
-  const requestFunc = requestFactory(`https://api.groq.com/openai/v1/${action}`);
+  const groqGatewayUrl = env.GROQ_GATEWAY_URL ?? 'https://api.groq.com/openai/v1';
+  const requestFunc = requestFactory(`${groqGatewayUrl}/${action}`);
   const response = await requestFunc(payload);
   const responseWithCors = corsAllowed(response);
   return responseWithCors;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -39,6 +39,7 @@ OPENAI_API_KEY = "sk-xxx"
 OPENAI_GATEWAY_URL = "https://gateway.ai.cloudflare.com/v1/xxx/xxx/openai"
 
 GROQ_CLOUD_TOKEN = "gsk_xxx"
+GROQ_GATEWAY_URL = "https://gateway.ai.cloudflare.com/v1/:uuid/:user/groq"
 
 COZE_API_KEY = "pat_xxxx"
 
@@ -53,4 +54,3 @@ DEEPINFRA_DEPLOY_NAME = [
     { "modelName" = "meta-llama/Meta-Llama-3-8B-Instruct", "gpt35Default" = true },
     { "modelName" = "meta-llama/Meta-Llama-3-70B-Instruct", "gpt4Default" = true },
 ]
-


### PR DESCRIPTION
Related to #15

This pull request introduces support for configuring gateway proxies for Groq, enhancing the flexibility and control over request routing. 

- **Updates `wrangler.toml`**: Adds a new variable `GROQ_GATEWAY_URL` to specify the Groq gateway URL, enabling the routing of requests through a specified gateway proxy.
- **Modifies `src/proxy/groq.ts`**: Utilizes the `GROQ_GATEWAY_URL` from environment variables for routing requests, with a fallback to the default Groq API URL if the gateway URL is not provided.
- **Revises `README.md`**: Includes a supplementary explanation for the current revision, detailing the new support for Groq gateway proxy configuration and its benefits for traffic management and performance optimization.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loadchange/openai-conversion-proxy/issues/15?shareId=2bc2ddda-60b8-4e45-be04-aa9f2bd29d71).