### PR TITLE
Support passing cozeApiUrl parameter for Coze API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { options } from './constant';
 import groq from './proxy/groq';
-import coze from './proxy/coze';
+import { coze, cozeChina } from './proxy/coze';
 import azure from './proxy/azure';
 import openai from './proxy/openai';
 import deepinfra from './proxy/deepinfra';
@@ -10,7 +10,7 @@ import { JSONParse, isNotEmpty } from './utils';
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    const services: { [key: string]: IProxy } = { groq, azure, openai, coze, deepinfra, deepseek };
+    const services: { [key: string]: IProxy } = { groq, azure, openai, coze, cozeChina, deepinfra, deepseek };
     const url = new URL(request.url);
     if (request.method === 'OPTIONS') return options;
 

--- a/src/proxy/coze.ts
+++ b/src/proxy/coze.ts
@@ -158,6 +158,10 @@ const proxy: IProxy = async (action: string, body: any, env: Env) => {
   const chat_history = body?.messages?.slice(0, -1) || [];
   const custom_variables = Object.create(null);
 
+  if (!env.COZE_API_URL) {
+    return new Response('COZE_API_URL environment variable is not defined', { status: 500 });
+  }
+
   const payload = {
     method: 'POST',
     headers: {
@@ -171,8 +175,7 @@ const proxy: IProxy = async (action: string, body: any, env: Env) => {
   };
 
   let { readable, writable } = new TransformStream();
-  const fetchAPI = 'https://api.coze.com/open_api/v2/chat';
-  let response = await fetch(fetchAPI, payload);
+  let response = await fetch(env.COZE_API_URL, payload);
   response = new Response(response.body, response);
   response.headers.set('Access-Control-Allow-Origin', '*');
 

--- a/src/proxy/coze.ts
+++ b/src/proxy/coze.ts
@@ -115,107 +115,119 @@ const convertToOpenAIFormat = async (params: IConvertToOpenAIFormatParams) => {
   writer.close();
 };
 
-const proxy: IProxy = async (action: string, body: any, env: Env) => {
-  if (env.COZE_BOT_IDS && typeof env.COZE_BOT_IDS === 'string') env.COZE_BOT_IDS = JSONParse(env.COZE_BOT_IDS);
-  if (!isNotEmpty(env.COZE_BOT_IDS)) {
-    return new Response('404 Not Found', { status: 404 });
-  }
+function serviceProviderRegion(region: 'cn' | 'global') {
+  return async (action: string, body: any, env: Env) => {
+    const config = {
+      cn: {
+        api: 'https://api.coze.cn/open_api/v2/chat',
+        token: env.COZE_CN_API_KEY,
+        botIds: env.COZE_CN_BOT_IDS,
+      },
+      global: {
+        api: 'https://api.coze.com/open_api/v2/chat',
+        token: env.COZE_GLOBAL_API_KEY,
+        botIds: env.COZE_GLOBAL_BOT_IDS,
+      },
+    }[region];
 
-  let [gpt35, gpt4] = Array(2).fill(env.COZE_BOT_IDS[0].botId);
-  const otherMapping: { [key: string]: string } = {};
-
-  if (listLen(env.COZE_BOT_IDS) > 1) {
-    env.COZE_BOT_IDS.forEach((item) => {
-      if (item.gpt35Default || item.gpt4Default) {
-        if (item.gpt35Default) gpt35 = item.botId;
-        if (item.gpt4Default) gpt4 = item.botId;
-      } else {
-        otherMapping[item.modelName] = item.botId;
-      }
-    });
-  }
-
-  const models_mapping = generativeModelMappings(gpt35, gpt4, otherMapping);
-  if (action === 'models') return models(models_mapping);
-
-  const created = parseInt((Date.now() / 1000).toFixed(0));
-
-  // Only chat/completions is supported
-  if (!['chat/completions'].includes(action)) {
-    return new Response('404 Not Found', { status: 404 });
-  }
-
-  let bot_id = '';
-  // if the model is number, then use it as bot_id
-  if (body?.model && !isNaN(Number(body?.model))) {
-    bot_id = body?.model;
-  } else {
-    bot_id = models_mapping[body?.model as OPEN_AI_MODELS] ?? gpt35;
-  }
-
-  const stream = Boolean(body?.stream);
-  const query = body?.messages?.slice(-1)?.[0]?.content || '';
-  const chat_history = body?.messages?.slice(0, -1) || [];
-  const custom_variables = Object.create(null);
-
-  if (!env.COZE_API_URL) {
-    return new Response('COZE_API_URL environment variable is not defined', { status: 500 });
-  }
-
-  const payload = {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: '*/*',
-      Host: 'api.coze.com',
-      Connection: 'keep-alive',
-      Authorization: `Bearer ${env.COZE_API_KEY}`,
-    },
-    body: JSON.stringify({ bot_id, conversation_id: '', user: 'User', query, chat_history, stream, custom_variables }),
-  };
-
-  let { readable, writable } = new TransformStream();
-  let response = await fetch(env.COZE_API_URL, payload);
-  response = new Response(response.body, response);
-  response.headers.set('Access-Control-Allow-Origin', '*');
-
-  if (!body?.stream) {
-    const data: any = await gatherResponse(response);
-    if (data?.code !== 0) {
-      return new Response(JSON.stringify({ error: data?.msg, code: data?.code }), { status: 400 });
+    if (config.botIds && typeof config.botIds === 'string') config.botIds = JSONParse(config.botIds);
+    if (!isNotEmpty(config.botIds)) {
+      return new Response('404 Not Found', { status: 404 });
     }
-    return new Response(
-      JSON.stringify({
-        id: `chatcmpl-${data?.conversation_id ?? Date.now()}`,
-        object: 'chat.completion',
-        created,
-        model: body?.model ?? 'gpt-3.5-turbo-1106',
-        system_fingerprint: 'fp_44709d6fcb',
-        choices: [
-          {
-            index: 0,
-            message: isNotEmpty(data?.messages) ? data.messages.filter((item: any) => item?.role === 'assistant' && item?.type === 'answer') : [],
-            logprobs: null,
-            finish_reason: 'stop',
+
+    let [gpt35, gpt4] = Array(2).fill(config.botIds[0].botId);
+    const otherMapping: { [key: string]: string } = {};
+
+    if (listLen(config.botIds) > 1) {
+      config.botIds.forEach((item) => {
+        if (item.gpt35Default || item.gpt4Default) {
+          if (item.gpt35Default) gpt35 = item.botId;
+          if (item.gpt4Default) gpt4 = item.botId;
+        } else {
+          otherMapping[item.modelName] = item.botId;
+        }
+      });
+    }
+
+    const models_mapping = generativeModelMappings(gpt35, gpt4, otherMapping);
+    if (action === 'models') return models(models_mapping);
+
+    const created = parseInt((Date.now() / 1000).toFixed(0));
+
+    // Only chat/completions is supported
+    if (!['chat/completions'].includes(action)) {
+      return new Response('404 Not Found', { status: 404 });
+    }
+
+    let bot_id = '';
+    // if the model is number, then use it as bot_id
+    if (body?.model && !isNaN(Number(body?.model))) {
+      bot_id = body?.model;
+    } else {
+      bot_id = models_mapping[body?.model as OPEN_AI_MODELS] ?? gpt35;
+    }
+
+    const stream = Boolean(body?.stream);
+    const query = body?.messages?.slice(-1)?.[0]?.content || '';
+    const chat_history = body?.messages?.slice(0, -1) || [];
+    const custom_variables = Object.create(null);
+
+    const payload = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+        Host: 'api.coze.com',
+        Connection: 'keep-alive',
+        Authorization: `Bearer ${config.token}`,
+      },
+      body: JSON.stringify({ bot_id, conversation_id: '', user: 'User', query, chat_history, stream, custom_variables }),
+    };
+
+    let { readable, writable } = new TransformStream();
+    let response = await fetch(config.api, payload);
+    response = new Response(response.body, response);
+    response.headers.set('Access-Control-Allow-Origin', '*');
+
+    if (!body?.stream) {
+      const data: any = await gatherResponse(response);
+      if (data?.code !== 0) {
+        return new Response(JSON.stringify({ error: data?.msg, code: data?.code }), { status: 400 });
+      }
+      return new Response(
+        JSON.stringify({
+          id: `chatcmpl-${data?.conversation_id ?? Date.now()}`,
+          object: 'chat.completion',
+          created,
+          model: body?.model ?? 'gpt-3.5-turbo-1106',
+          system_fingerprint: 'fp_44709d6fcb',
+          choices: [
+            {
+              index: 0,
+              message: isNotEmpty(data?.messages) ? data.messages.filter((item: any) => item?.role === 'assistant' && item?.type === 'answer') : [],
+              logprobs: null,
+              finish_reason: 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: 9,
+            completion_tokens: 12,
+            total_tokens: 21,
           },
-        ],
-        usage: {
-          prompt_tokens: 9,
-          completion_tokens: 12,
-          total_tokens: 21,
-        },
-      }),
-      { headers: { 'Content-Type': 'application/json' } }
-    );
-  }
+        }),
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+    }
 
-  convertToOpenAIFormat({
-    model: body?.model ?? 'gpt-3.5-turbo-1106',
-    created,
-    readable: response.body as ReadableStream,
-    writable,
-  });
-  return new Response(readable, response);
-};
+    convertToOpenAIFormat({
+      model: body?.model ?? 'gpt-3.5-turbo-1106',
+      created,
+      readable: response.body as ReadableStream,
+      writable,
+    });
+    return new Response(readable, response);
+  };
+}
 
-export default proxy;
+export const coze: IProxy = serviceProviderRegion('global');
+export const cozeChina: IProxy = serviceProviderRegion('cn');

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,10 +89,17 @@ interface Env {
 
   /**
    * Coze Configuration
+   * @website https://www.coze.cn/docs/developer_guides/coze_api_overview
+   */
+  COZE_CN_API_KEY: string;
+  COZE_CN_BOT_IDS: CozeBot[];
+
+  /**
+   * Coze Configuration
    * @website https://www.coze.com/open
    */
-  COZE_API_KEY: string;
-  COZE_BOT_IDS: CozeBot[];
+  COZE_GLOBAL_API_KEY: string;
+  COZE_GLOBAL_BOT_IDS: CozeBot[];
 
   /**
    * DeepInfra Configuration

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,28 +10,28 @@ GOOGLE_CSE_ID = "xxx"
 
 AZURE_API_VERSION = "2024-02-15-preview"
 AZURE_API_KEYS = [
-    { "resourceName" = "us-w", "token" = "xxxxxx", "default" = true },
-    { "resourceName" = "us-e", "token" = "xxxxxx", "models" = [
-        "dall-e-3",
-        "text-embedding-3-small",
-        "text-embedding-3-large",
-    ] },
-    { "resourceName" = "us-nc", "token" = "xxxxxx", "models" = [
-        "gpt-3.5-turbo-0125",
-        "gpt-4-0125-preview",
-    ] },
+	{ "resourceName" = "us-w", "token" = "xxxxxx", "default" = true },
+	{ "resourceName" = "us-e", "token" = "xxxxxx", "models" = [
+		"dall-e-3",
+		"text-embedding-3-small",
+		"text-embedding-3-large",
+	] },
+	{ "resourceName" = "us-nc", "token" = "xxxxxx", "models" = [
+		"gpt-3.5-turbo-0125",
+		"gpt-4-0125-preview",
+	] },
 ]
 AZURE_DEPLOY_NAME = [
-    { "deployName" = "gpt-35-turbo", "modelName" = "gpt-3.5-turbo", "gpt35Default" = true },
-    { "deployName" = "gpt-4-turbo", "modelName" = "gpt-4-turbo-preview", "gpt4Default" = true },
-    { "deployName" = "gpt-4-vision-preview", "modelName" = "gpt-4-vision-preview" },
-    { "deployName" = "gpt-4-vision-preview", "modelName" = "gpt-4-1106-vision-preview" },
-    { "deployName" = "text-embedding-ada-002-2", "modelName" = "text-embedding-ada-002" },
-    { "deployName" = "Dalle3", "modelName" = "dall-e-3" },
-    { "deployName" = "text-embedding-3-large", "modelName" = "text-embedding-3-large" },
-    { "deployName" = "text-embedding-3-small", "modelName" = "text-embedding-3-small" },
-    { "deployName" = "gpt-35-turbo-0125", "modelName" = "gpt-3.5-turbo-0125" },
-    { "deployName" = "gpt-4-turbo-0125", "modelName" = "gpt-4-0125-preview" },
+	{ "deployName" = "gpt-35-turbo", "modelName" = "gpt-3.5-turbo", "gpt35Default" = true },
+	{ "deployName" = "gpt-4-turbo", "modelName" = "gpt-4-turbo-preview", "gpt4Default" = true },
+	{ "deployName" = "gpt-4-vision-preview", "modelName" = "gpt-4-vision-preview" },
+	{ "deployName" = "gpt-4-vision-preview", "modelName" = "gpt-4-1106-vision-preview" },
+	{ "deployName" = "text-embedding-ada-002-2", "modelName" = "text-embedding-ada-002" },
+	{ "deployName" = "Dalle3", "modelName" = "dall-e-3" },
+	{ "deployName" = "text-embedding-3-large", "modelName" = "text-embedding-3-large" },
+	{ "deployName" = "text-embedding-3-small", "modelName" = "text-embedding-3-small" },
+	{ "deployName" = "gpt-35-turbo-0125", "modelName" = "gpt-3.5-turbo-0125" },
+	{ "deployName" = "gpt-4-turbo-0125", "modelName" = "gpt-4-0125-preview" },
 ]
 AZURE_GATEWAY_URL = "https://gateway.ai.cloudflare.com/v1/xxx/xxx/azure-openai"
 
@@ -41,17 +41,22 @@ OPENAI_GATEWAY_URL = "https://gateway.ai.cloudflare.com/v1/xxx/xxx/openai"
 GROQ_CLOUD_TOKEN = "gsk_xxx"
 GROQ_GATEWAY_URL = "https://gateway.ai.cloudflare.com/v1/:uuid/:user/groq"
 
-COZE_API_KEY = "pat_xxxx"
-COZE_API_URL = "https://api.coze.com/open_api/v2/chat"
+COZE_CN_API_KEY = "pat_xxxx"
+COZE_CN_BOT_IDS = [
+	{ "botId" = "7332758701796813850", "gpt35Default" = true, "gpt4Default" = true, "modelName" = "gpt4" },
+	{ "botId" = "7337493361170399237", "modelName" = "WebDeveloper" },
+	{ "botId" = "7332758701795818950", "modelName" = "GithubExpert" },
+]
 
-COZE_BOT_IDS = [
-    { "botId" = "7332758701796813850", "gpt35Default" = true, "gpt4Default" = true, "modelName" = "gpt4" },
-    { "botId" = "7337493361170399237", "modelName" = "WebDeveloper" },
-    { "botId" = "7332758701795818950", "modelName" = "GithubExpert" },
+COZE_GLOBAL_API_KEY = "pat_xxxx"
+COZE_GLOBAL_BOT_IDS = [
+	{ "botId" = "7332758701796813850", "gpt35Default" = true, "gpt4Default" = true, "modelName" = "gpt4" },
+	{ "botId" = "7337493361170399237", "modelName" = "WebDeveloper" },
+	{ "botId" = "7332758701795818950", "modelName" = "GithubExpert" },
 ]
 
 DEEPINFRA_API_KEY = "xxxxx"
 DEEPINFRA_DEPLOY_NAME = [
-    { "modelName" = "meta-llama/Meta-Llama-3-8B-Instruct", "gpt35Default" = true },
-    { "modelName" = "meta-llama/Meta-Llama-3-70B-Instruct", "gpt4Default" = true },
+	{ "modelName" = "meta-llama/Meta-Llama-3-8B-Instruct", "gpt35Default" = true },
+	{ "modelName" = "meta-llama/Meta-Llama-3-70B-Instruct", "gpt4Default" = true },
 ]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -42,6 +42,7 @@ GROQ_CLOUD_TOKEN = "gsk_xxx"
 GROQ_GATEWAY_URL = "https://gateway.ai.cloudflare.com/v1/:uuid/:user/groq"
 
 COZE_API_KEY = "pat_xxxx"
+COZE_API_URL = "https://api.coze.com/open_api/v2/chat"
 
 COZE_BOT_IDS = [
     { "botId" = "7332758701796813850", "gpt35Default" = true, "gpt4Default" = true, "modelName" = "gpt4" },


### PR DESCRIPTION
closed #17

Adds support for dynamically setting the Coze API URL through environment variables, enhancing the proxy's flexibility for accessing the Coze.cn API.

- Replaces the hardcoded Coze API URL in `src/proxy/coze.ts` with `env.COZE_API_URL`, allowing the API URL to be set dynamically.
- Introduces a check in `src/proxy/coze.ts` to ensure `env.COZE_API_URL` is defined before making the API request, improving error handling.
- Adds a new variable `COZE_API_URL` under `[vars]` in `wrangler.toml`, with a default value pointing to the Coze API, facilitating easy configuration.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loadchange/openai-conversion-proxy/issues/17?shareId=2d48fb4e-612e-45e4-8d5b-e056d73663c5).