### PR TITLE
Support for OpenAI's Latest GPT-4o-mini Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,27 @@ We welcome and encourage contributions from community members in any form! If yo
 ## License
 
 This project is released under the MIT license. More details can be found in the [LICENSE](LICENSE) file.
+
+## Supported Models
+
+The project supports the following models:
+
+- GPT-4o
+- GPT-4o-mini
+- GPT-4o-2024-05-13
+- GPT-4-0125-preview
+- GPT-4-turbo-preview
+- GPT-4-1106-preview
+- GPT-4-vision-preview
+- GPT-4-1106-vision-preview
+- GPT-4
+- GPT-4-0613
+- GPT-4-32k
+- GPT-4-32k-0613
+- GPT-3.5-turbo-0125
+- GPT-3.5-turbo
+- GPT-3.5-turbo-1106
+- GPT-3.5-turbo-instruct
+- GPT-3.5-turbo-16k
+- GPT-3.5-turbo-0613
+- GPT-3.5-turbo-16k-0613

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -8,6 +8,7 @@ export const options = new Response(null, {
 
 export const supportedModels = [
   'gpt-4o',
+  'gpt-4o-mini',
   'gpt-4o-2024-05-13',
   'gpt-4-0125-preview',
   'gpt-4-turbo-preview',

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -9,6 +9,7 @@ export const generativeModelMappings = (GPT35_TURBO: string, GPT4_TURBO?: string
   if (!GPT4_TURBO) GPT4_TURBO = GPT35_TURBO;
   return {
     'gpt-4o': GPT4_TURBO,
+    'gpt-4o-mini': GPT4_TURBO,
     'gpt-4o-2024-05-13': GPT4_TURBO,
     'gpt-4-turbo': GPT4_TURBO,
     'gpt-4-turbo-2024-04-09': GPT4_TURBO,


### PR DESCRIPTION
closed #22

Add support for OpenAI's GPT-4o-mini model.

* **Model Support**:
  - Add 'gpt-4o-mini' to the `supportedModels` array in `src/constant.ts`.
  - Update `generativeModelMappings` in `src/utils/helper.ts` to include 'gpt-4o-mini'.
* **Documentation**:
  - Update `README.md` to mention GPT-4o-mini in the supported models section.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loadchange/openai-conversion-proxy/issues/22?shareId=ff360c23-917d-4d08-8244-3cd67633a04d).