### PR TITLE
Update Groq section to support Llama 3.1 model

### DIFF
--- a/src/proxy/groq.ts
+++ b/src/proxy/groq.ts
@@ -3,7 +3,17 @@ import { models, generativeModelMappings, requestFactory, openAiPayload, corsAll
 /**
  * Documentation: https://console.groq.com/docs/models
  */
-const MODELS = ['llama3-8b-8192', 'llama3-70b-8192', 'llama2-70b-4096', 'mixtral-8x7b-32768', 'gemma-7b-it'];
+const MODELS = [
+  'llama3-8b-8192',
+  'llama3-70b-8192',
+  'llama2-70b-4096',
+  'mixtral-8x7b-32768',
+  'gemma-7b-it',
+  'gemma2-9b-it',
+  'llama-3.1-405b-reasoning',
+  'llama-3.1-70b-versatile',
+  'llama-3.1-8b-instant'
+];
 
 /**
  * Mapping of model names to their corresponding GPT versions.
@@ -13,8 +23,8 @@ const MODELS = ['llama3-8b-8192', 'llama3-70b-8192', 'llama2-70b-4096', 'mixtral
  * - LLaMA3_70b_8k (llama3-70b-8192) => GPT-4 ALL
  */
 const MODELS_MAPPING = generativeModelMappings(
-  'mixtral-8x7b-32768',
-  'llama3-70b-8192',
+  'llama-3.1-8b-instant',
+  'llama-3.1-70b-versatile',
   MODELS.reduce((acc, model) => ({ ...acc, [model]: model }), {})
 );
 


### PR DESCRIPTION
closed #24

Update the Groq section to include the Llama 3.1 model.

* Add Llama 3.1 models to the `MODELS` array in `src/proxy/groq.ts`: `llama-3.1-405b-reasoning`, `llama-3.1-70b-versatile`, `llama-3.1-8b-instant`.
* Update `MODELS_MAPPING` in `src/proxy/groq.ts` to include the new Llama 3.1 models.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loadchange/openai-conversion-proxy/issues/24?shareId=d328aeca-c642-42cf-a7ea-947ccd984205).